### PR TITLE
Fixed preupgrade failure if vm names didn't match

### DIFF
--- a/app/controllers/api/v2/preupgrade_reports_controller.rb
+++ b/app/controllers/api/v2/preupgrade_reports_controller.rb
@@ -3,13 +3,21 @@
 module Api
   module V2
     class PreupgradeReportsController < ::Api::V2::BaseController
+      before_action :resolve_host, only: [:create]
+      def resolve_host
+        host_name_or_id = params['host']
+        @host = Host.where(:name => host_name_or_id).or(Host.where(:id => host_name_or_id)).first
+      end
+
       def create
         date = DateTime.now.utc
-        host_name_or_id = params['host']
         status = params['status']
-        host = Host.where(:name => host_name_or_id).or(Host.where(:id => host_name_or_id)).first
-        report = PreupgradeReport.create_report(host, date, status, params['preupgrade_report'])
-        render :json => report
+        if @host.nil?
+          render :json => { "error": format("Couldn't find host %<host>s", host: params['host']) }
+        else
+          report = PreupgradeReport.create_report(@host, date, status, params['preupgrade_report'])
+          render :json => report
+        end
       end
 
       def show

--- a/app/views/foreman_leapp/job_templates/preupgrade.erb
+++ b/app/views/foreman_leapp/job_templates/preupgrade.erb
@@ -24,5 +24,5 @@ template_inputs:
 
 leapp preupgrade <%= "--debug" if input('debug') == "true" %>
 # XXX FIXME probably will be moved to client
-echo "{\"preupgrade_report\": $(cat /var/log/leapp/leapp-report.json), \"host\": \"$(hostname)\", \"status\": $(echo $?)}" > /tmp/foreman_leapp_preupgrade.json
+echo "{\"preupgrade_report\": $(cat /var/log/leapp/leapp-report.json), \"host\": \"<%=@host.name%>\", \"status\": $(echo $?)}" > /tmp/foreman_leapp_preupgrade.json
 curl -H 'Content-Type: application/json' -u <%=input('leapp_auth_user_input')%>:<%=input('leapp_auth_token_input')%> -X POST <%=foreman_server_url%>/api/v2/preupgrade_reports -d @/tmp/foreman_leapp_preupgrade.json


### PR DESCRIPTION
Previously if vm's hostname was different from the
foreman name the preupgrade template job would fail
with cryptic error. That was fixed by:
- passing actual vm's foreman name as one of the params
  of preupgrade_report upload request;
- adding a check in create method that would ensure a
  host with given name is known to foreman.